### PR TITLE
Standardizing how to handle non-existing node ID

### DIFF
--- a/spec/KnowledgeGraph.md
+++ b/spec/KnowledgeGraph.md
@@ -111,7 +111,7 @@ Note: This is an example of a non-normative note.
 
 # [Data Structure](Section%202%20--%20Data%20Structure.md)
 
-# [Execution](Section%203%20--%20DExecution.md)
+# [Execution](Section%203%20--%20Execution.md)
 
 # [Appendix: Notation Conventions](Appendix%20A%20--%20Notation%20Conventions.md)
 

--- a/spec/KnowledgeGraph.md
+++ b/spec/KnowledgeGraph.md
@@ -111,6 +111,8 @@ Note: This is an example of a non-normative note.
 
 # [Data Structure](Section%202%20--%20Data%20Structure.md)
 
+# [Execution](Section%203%20--%20DExecution.md)
+
 # [Appendix: Notation Conventions](Appendix%20A%20--%20Notation%20Conventions.md)
 
 # [Appendix: Grammar Summary](Appendix%20B%20--%20Grammar%20Summary.md)

--- a/spec/Section 3 -- Execution.md
+++ b/spec/Section 3 -- Execution.md
@@ -1,0 +1,15 @@
+# Execution
+
+A Knowledge Graph library or service transforms or operates on a Knowledge Graph Spec via execution.
+
+Note: The Knowledge Graph Spec do not require any specific serialization format or transport mechanism. Message 
+serialization and transport mechanisms should be chosen by the implementing library or service.
+
+## Executing Links
+
+### Handling Node ID Errors
+
+A _node ID error_ is an error raised from a particular link during execution. These errors should be reported at
+runtime.
+
+If a node ID (either source or target) is not found, a runtime error should be reported.

--- a/spec/Section 3 -- Execution.md
+++ b/spec/Section 3 -- Execution.md
@@ -1,15 +1,18 @@
 # Execution
 
-A Knowledge Graph library or service transforms or operates on a Knowledge Graph Spec via execution.
+A Knowledge Graph library or service transforms or operates on a Knowledge Graph
+Spec via execution.
 
-Note: The Knowledge Graph Spec do not require any specific serialization format or transport mechanism. Message 
-serialization and transport mechanisms should be chosen by the implementing library or service.
+Note: The Knowledge Graph Spec do not require any specific serialization format
+or transport mechanism. Message serialization and transport mechanisms should be
+chosen by the implementing library or service.
 
 ## Executing Links
 
 ### Handling Node ID Errors
 
-A _node ID error_ is an error raised from a particular link during execution. These errors should be reported at
-runtime.
+A _node ID error_ is an error raised from a particular link during execution.
+These errors should be reported at runtime.
 
-If a node ID (either source or target) is not found, a runtime error should be reported.
+If a node ID (either source or target) is not found, a runtime error should be
+reported.


### PR DESCRIPTION
## Changelog

### Added

- Specified how to handle when a link source node ID or target node ID does not exist.

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Checklist

- [x] Test
- [x] Self-review
- [x] Documentation
